### PR TITLE
Adds settings to control tile validation

### DIFF
--- a/afrh_prj/settings.py
+++ b/afrh_prj/settings.py
@@ -147,6 +147,10 @@ CACHES = {
     }
 }
 
+BYPASS_CARDINALITY_TILE_VALIDATION = True
+BYPASS_UNIQUE_CONSTRAINT_TILE_VALIDATION = False
+BYPASS_REQUIRED_VALUE_TILE_VALIDATION = False
+
 #Identify the usernames and duration (seconds) for which you want to cache the time wheel
 CACHE_BY_USER = {'anonymous': 3600 * 24}
 


### PR DESCRIPTION
There are many cards that violate tile cardinality validation. These settings allow us to bypass the validation until the business data can be corrected.